### PR TITLE
Bumped rfg-api dependency to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-real-favicon",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Generate a multiplatform favicon with RealFaviconGenerator",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "ansi-colors": "^1.1.0",
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.1",
-    "rfg-api": "^0.5.0",
+    "rfg-api": "^0.5.2",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
Updated from 0.5.0 to 0.5.2 in order to fix security issues rated as "high" severity by npm audit.